### PR TITLE
Add WebAssembly SIMD support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 AM_CFLAGS = -I$(top_srcdir)/include $(DEPS_CFLAGS)
 
-dist_doc_DATA = COPYING AUTHORS README
+dist_doc_DATA = COPYING AUTHORS README.md
 
 include_HEADERS = include/rnnoise.h
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ $ ./configure
 $ make
 ```
 
+### WebAssembly SIMDを有効にする場合
+
+以下のように`--enable-wasm-simd`を指定して`configure`を実行してください:
+```console
+$ ./configure --enable-wasm-simd
+```
+
 ## ライセンス
 
 修正BSDライセンスです。詳細は[COPYING](COPYING)を参照してください。

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,14 @@ AS_IF([test "$enable_assertions" = "yes"], [
   AC_DEFINE([OP_ENABLE_ASSERTIONS], [1], [Enable assertions in code])
 ])
 
+AC_ARG_ENABLE([wasm_simd],
+  AS_HELP_STRING([--enable-wasm-simd], [Enable WebAssembly SIMD in code]),,
+  enable_wasm_simd=no)
+
+AS_IF([test "$enable_wasm_simd" = "yes"], [
+  AC_DEFINE([ENABLE_WASM_SIMD], [1], [Enable WebAssembly SIMD in code])
+])
+
 AC_ARG_ENABLE([examples],
   AS_HELP_STRING([--disable-examples], [Do not build example applications]),,
   enable_examples=yes)
@@ -120,6 +128,8 @@ AC_MSG_NOTICE([
   $PACKAGE_NAME $PACKAGE_VERSION: Automatic configuration OK.
 
     Assertions ................... ${enable_assertions}
+
+    WebAssembly SIMD ................... ${enable_wasm_simd}
 
     Hidden visibility ............ ${cc_cv_flag_visibility}
 


### PR DESCRIPTION
`rnn.c`の`compute_gru`関数をWebAssemblyのSIMDに対応させました。
これによって手元の環境（mac, chrome）では、`rnnoise_process_frame`関数の処理時間が1.5~2倍程度短くなっています。

変更点:
- `./configure`に `--enable-wasm-simd`オプションを追加
- 上のオプションが指定されている場合には`compute_gru`のSIMD版を使用