### PR TITLE
エラー処理を改善

### DIFF
--- a/src/rnn.c
+++ b/src/rnn.c
@@ -29,6 +29,7 @@
 #include "config.h"
 #endif
 
+#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include "arch.h"
@@ -96,7 +97,8 @@ void compute_dense(const DenseLayer* layer, float* output, const float* input) {
     for (i = 0; i < N; i++)
       output[i] = relu(output[i]);
   } else {
-    *(int*)0 = 0;
+    /* rnn_reader.cのINPUT_ACTIVATIONマクロによる初期化処理的にここに来ることはない */
+    assert(0);
   }
 }
 
@@ -226,7 +228,8 @@ static void _compute_gru_output_wasm_simd(const GRULayer* gru,
     else if (gru->activation == ACTIVATION_RELU)
       sum = relu(WEIGHTS_SCALE * sum);
     else
-      *(int*)0 = 0;
+      /* rnn_reader.cのINPUT_ACTIVATIONマクロによる初期化処理的にここに来ることはない */
+      assert(0);
 
     state[i] = z[i] * state[i] + (1 - z[i]) * sum;
   }
@@ -287,7 +290,8 @@ void compute_gru(const GRULayer* gru, float* state, const float* input) {
     else if (gru->activation == ACTIVATION_RELU)
       sum = relu(WEIGHTS_SCALE * sum);
     else
-      *(int*)0 = 0;
+      /* rnn_reader.cのINPUT_ACTIVATIONマクロによる初期化処理的にここに来ることはない */
+      assert(0);
     h[i] = z[i] * state[i] + (1 - z[i]) * sum;
   }
   for (i = 0; i < N; i++)


### PR DESCRIPTION
`develop`ブランチをコンパイルする際に、以下の警告が出ていたので、その修正となります:
```
src/rnn.c:99:5: warning: indirection of non-volatile null pointer will be deleted, not trap [-Wnull-dereference]
    *(int*)0 = 0;
    ^~~~~~~~
src/rnn.c:99:5: note: consider using __builtin_trap() or qualifying pointer with 'volatile'
```

該当行自体は、コード的に、絶対実行されないパスに存在するものだったので、コメント+assertで置換することで意図をより明確にしました。
なお、この修正に音声の処理結果が変わらないことは `shiguredo/rnnoise-wasm` のユニットテストで確認済みです。